### PR TITLE
Add a differ tool

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,7 +13,7 @@ This repo is a **Python tool** for working with Final Draft `.fdx` screenplay fi
   - **`metadata.py`** – `compute_screenplay_metadata(screenplay)` for scene/character/line stats (used when `parse --metadata`).
   - **`source_file_info.py`** – `source_file_info(path)` for optional `parse --file-info` JSON (`path_resolved`, `size_bytes`, timestamps).
   - **`parse_json_diff.py`** – `build_diff_report`, `load_parse_json`, `scene_digests` for `cli.py diff`.
-  - **`utils.py`** – Logging helpers.
+  - **`utils.py`** – Logging helpers; `strip_run_varying_ids` (shared checksum / diff normalization).
 - **`cli.py`** – Entry point: subcommands `run`, `parse`, `fountain`, `diff` (see Commands). Parse output always includes `nonce`, `parser_version`, `parse_datetime`; with `--checksum`, adds a `checksums` object (SHA-256 per section plus `scene_checksums`, one digest per scene in order).
 - **`tests/`** – Unified test suite (pytest). **`tests/fixtures/`** – FDX and other test fixtures (e.g. `sample.fdx`).
 - **`samples/`** – Sample FDX files for manual use.
@@ -61,7 +61,7 @@ python cli.py parse -f path/to/script.fdx -o script.json \
 
 # Diff two parse JSON files (JSON report to stdout or -o)
 python cli.py diff --before older.json --after newer.json
-python cli.py diff -a older.json -b newer.json -o report.json
+python cli.py diff -b older.json -a newer.json -o report.json
 
 # Emit FDX → Fountain to stdout
 python cli.py fountain -f path/to/script.fdx

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,6 +1,6 @@
 # Agent instructions (schoonmaker)
 
-This repo is a **Python tool** for working with Final Draft `.fdx` screenplay files. It parses FDX XML, builds a structured model, and can output JSON AST or Fountain text.
+This repo is a **Python tool** for working with Final Draft `.fdx` screenplay files. It parses FDX XML, builds a structured model, and can output JSON AST or Fountain text, or diff two parse JSON snapshots.
 
 ## Layout
 
@@ -12,8 +12,9 @@ This repo is a **Python tool** for working with Final Draft `.fdx` screenplay fi
   - **`cli_arg_parser.py`** – CLI argument parsing (file path, subcommands).
   - **`metadata.py`** – `compute_screenplay_metadata(screenplay)` for scene/character/line stats (used when `parse --metadata`).
   - **`source_file_info.py`** – `source_file_info(path)` for optional `parse --file-info` JSON (`path_resolved`, `size_bytes`, timestamps).
+  - **`parse_json_diff.py`** – `build_diff_report`, `load_parse_json`, `scene_digests` for `cli.py diff`.
   - **`utils.py`** – Logging helpers.
-- **`cli.py`** – Entry point: subcommands `run`, `parse`, `fountain` (see Commands). Parse output always includes `nonce`, `parser_version`, `parse_datetime`; with `--checksum`, adds a `checksums` object (SHA-256 per section plus `scene_checksums`, one digest per scene in order).
+- **`cli.py`** – Entry point: subcommands `run`, `parse`, `fountain`, `diff` (see Commands). Parse output always includes `nonce`, `parser_version`, `parse_datetime`; with `--checksum`, adds a `checksums` object (SHA-256 per section plus `scene_checksums`, one digest per scene in order).
 - **`tests/`** – Unified test suite (pytest). **`tests/fixtures/`** – FDX and other test fixtures (e.g. `sample.fdx`).
 - **`samples/`** – Sample FDX files for manual use.
 - **`requirements.txt`** – Runtime deps (empty or minimal for stdlib-only use).
@@ -57,6 +58,10 @@ python cli.py parse -f path/to/script.fdx -o script.json --file-info
 # All optional parse flags together (metadata, checksums, source file stats)
 python cli.py parse -f path/to/script.fdx -o script.json \
   --metadata --checksum --file-info
+
+# Diff two parse JSON files (JSON report to stdout or -o)
+python cli.py diff --before older.json --after newer.json
+python cli.py diff -a older.json -b newer.json -o report.json
 
 # Emit FDX → Fountain to stdout
 python cli.py fountain -f path/to/script.fdx

--- a/README.md
+++ b/README.md
@@ -64,8 +64,8 @@ python cli.py fountain -f path/to/script.fdx -o script.fountain
 # Use --metadata on both parses for word counts, characters, and locations.
 python cli.py diff --before script_v1.json --after script_v2.json -o diff.json
 
-# Same with short flags (stdout if you omit -o)
-python cli.py diff -a old.json -b new.json
+# Same with short flags (-b = --before, -a = --after; stdout if you omit -o)
+python cli.py diff -b old.json -a new.json
 ```
 
 ## Docker

--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ Features:
 - **Parse & summary** – Parse FDX and print a short summary (document type, version, scene count) with `cli.py run`.
 - **FDX → JSON AST** – Streaming-style parser producing dataclasses (Scene, DialogueBlock, Action, etc.); emit with `cli.py parse`.
 - **FDX → Fountain** – Convert parsed screenplay to Fountain format with `cli.py fountain`.
+- **Parse JSON diff** – Compare two `parse` JSON snapshots (e.g. two saves of the same script) with `cli.py diff`; reports word/element deltas, changed scene indices, character and location changes as JSON.
 
 Ultimate goal: GitHub Action, PDF handling, spell check, etc.
 
@@ -58,6 +59,13 @@ python cli.py fountain -f path/to/script.fdx
 
 # Write Fountain to a file
 python cli.py fountain -f path/to/script.fdx -o script.fountain
+
+# Compare two parse JSON files (before = earlier save, after = later)
+# Use --metadata on both parses for word counts, characters, and locations.
+python cli.py diff --before script_v1.json --after script_v2.json -o diff.json
+
+# Same with short flags (stdout if you omit -o)
+python cli.py diff -a old.json -b new.json
 ```
 
 ## Docker
@@ -71,5 +79,7 @@ docker compose build && docker compose run --rm schoonmaker
 ```
 
 Parse JSON output always includes **`nonce`** (unique per run), **`parser_version`** (from `schoonmaker.version`), and **`parse_datetime`** (UTC ISO). With **`--checksum`**, a **`checksums`** object is added with SHA-256 hashes for `alt_collection`, `scenes`, `title_page`, and `preamble` (each is the hash of canonical JSON of that section after normalizing away run-varying IDs). **`scene_checksums`** is a parallel list of SHA-256 digests, one per scene in order, so a diff can show which scene indices changed without re-parsing the full `scenes` array. With **`--file-info`**, a **`source_file`** object records the input path (as given and resolved), basename, **`size_bytes`**, and UTC ISO **`modified`** / **`accessed`** times; **`created`** is included when the OS exposes it (e.g. Windows, macOS).
+
+The **`diff`** subcommand reads two parse JSON files and writes a report with **`scenes`** (counts, **`changed_indices`**, **`added_scene_indices`**, **`removed_scene_indices`**), **`counts`** (word and paragraph totals with before/after/delta), **`elements`** (action, dialogue lines, etc.), **`characters`** (new, removed, line/scene deltas), and **`locations`** (summary and per-location scene-count changes). Pass **`--metadata`** when generating both JSON files for full stats; scene-level changes are always derived from **`scenes`** using the same digest rules as parse checksums (stale **`scene_checksums`** in hand-edited JSON are not trusted).
 
 See **AGENTS.md** for layout, conventions, and full command reference.

--- a/cli.py
+++ b/cli.py
@@ -14,6 +14,11 @@ from dataclasses import asdict
 from schoonmaker.cli_arg_parser import CLIArgParser
 from schoonmaker.fdx import FDXParser, screenplay_to_fountain
 from schoonmaker.metadata import compute_screenplay_metadata
+from schoonmaker.parse_json_diff import (
+    build_diff_report,
+    diff_report_to_json,
+    load_parse_json,
+)
 from schoonmaker.source_file_info import source_file_info
 from schoonmaker.utils import set_up_logging, get_logger
 from schoonmaker.version import version as parser_version
@@ -162,6 +167,20 @@ def run_fountain(args) -> int:
     return _write_output(payload, getattr(args, "output", None))
 
 
+def run_diff(args) -> int:
+    """Compare two parse JSON files; emit structured diff report JSON."""
+    doc_a = load_parse_json(args.before)
+    doc_b = load_parse_json(args.after)
+    report = build_diff_report(
+        doc_a,
+        doc_b,
+        label_a="before",
+        label_b="after",
+    )
+    payload = diff_report_to_json(report)
+    return _write_output(payload, getattr(args, "output", None))
+
+
 def main() -> int:
     args = CLIArgParser.get_cli_args()
     log.info("cli_args: %s", args)
@@ -172,6 +191,8 @@ def main() -> int:
         return run_parse(args)
     if args.command == "fountain":
         return run_fountain(args)
+    if args.command == "diff":
+        return run_diff(args)
 
     log.error("Unknown command: %s", args.command)
     return 2

--- a/cli.py
+++ b/cli.py
@@ -20,7 +20,7 @@ from schoonmaker.parse_json_diff import (
     load_parse_json,
 )
 from schoonmaker.source_file_info import source_file_info
-from schoonmaker.utils import set_up_logging, get_logger
+from schoonmaker.utils import get_logger, set_up_logging, strip_run_varying_ids
 from schoonmaker.version import version as parser_version
 
 set_up_logging()
@@ -46,18 +46,6 @@ def run_summary(args) -> int:
         n_scenes,
     )
     return 0
-
-
-def _strip_run_varying_ids(val: object) -> object:
-    """Recursively remove id and dual_group from dicts for stable checksums."""
-    if isinstance(val, dict):
-        out = dict(val)
-        out.pop("id", None)
-        out.pop("dual_group", None)
-        return {k: _strip_run_varying_ids(v) for k, v in out.items()}
-    if isinstance(val, list):
-        return [_strip_run_varying_ids(item) for item in val]
-    return val
 
 
 def _normalize_for_checksum(key: str, val: object) -> object:
@@ -122,7 +110,7 @@ def _compute_output_checksums(out: dict) -> dict[str, object]:
                 normalized = _normalize_metadata_for_checksum(val, id_to_index)
             else:
                 normalized = _normalize_for_checksum(key, val)
-                normalized = _strip_run_varying_ids(normalized)
+                normalized = strip_run_varying_ids(normalized)
             canonical = json.dumps(
                 normalized, sort_keys=True, ensure_ascii=False
             )

--- a/schoonmaker/cli_arg_parser.py
+++ b/schoonmaker/cli_arg_parser.py
@@ -9,7 +9,10 @@ class CLIArgParser(object):
     def __init__(self):
         self.parser = ArgumentParser(
             prog="schoonmaker",
-            description="Parse FDX files; export JSON AST or Fountain.",
+            description=(
+                "Parse FDX; export JSON AST or Fountain; "
+                "diff two parse JSON snapshots."
+            ),
         )
         subparsers = self.parser.add_subparsers(dest="command", required=True)
 
@@ -70,6 +73,34 @@ class CLIArgParser(object):
             "-o", "--output", type=str, help="Path to output Fountain file"
         )
         fountain_parser.set_defaults(command="fountain")
+
+        diff_parser = subparsers.add_parser(
+            "diff",
+            help="Compare two parse JSON files (before/after)",
+        )
+        diff_parser.add_argument(
+            "--before",
+            "-a",
+            type=str,
+            required=True,
+            metavar="PATH",
+            help="Earlier parse JSON (baseline)",
+        )
+        diff_parser.add_argument(
+            "--after",
+            "-b",
+            type=str,
+            required=True,
+            metavar="PATH",
+            help="Later parse JSON",
+        )
+        diff_parser.add_argument(
+            "-o",
+            "--output",
+            type=str,
+            help="Write diff report JSON to this path (default: stdout)",
+        )
+        diff_parser.set_defaults(command="diff")
 
     def _parse_args(self) -> Namespace:
         return self.parser.parse_args()

--- a/schoonmaker/cli_arg_parser.py
+++ b/schoonmaker/cli_arg_parser.py
@@ -80,19 +80,19 @@ class CLIArgParser(object):
         )
         diff_parser.add_argument(
             "--before",
-            "-a",
-            type=str,
-            required=True,
-            metavar="PATH",
-            help="Earlier parse JSON (baseline)",
-        )
-        diff_parser.add_argument(
-            "--after",
             "-b",
             type=str,
             required=True,
             metavar="PATH",
-            help="Later parse JSON",
+            help="Earlier parse JSON baseline (-b for --before)",
+        )
+        diff_parser.add_argument(
+            "--after",
+            "-a",
+            type=str,
+            required=True,
+            metavar="PATH",
+            help="Later parse JSON (-a for --after)",
         )
         diff_parser.add_argument(
             "-o",

--- a/schoonmaker/parse_json_diff.py
+++ b/schoonmaker/parse_json_diff.py
@@ -7,6 +7,8 @@ import json
 from pathlib import Path
 from typing import Any
 
+from schoonmaker.utils import strip_run_varying_ids
+
 
 DIFF_REPORT_VERSION = 1
 
@@ -21,24 +23,12 @@ def load_parse_json(path: str | Path) -> dict[str, Any]:
     return data
 
 
-def _strip_run_varying_ids(val: object) -> object:
-    """Match checksum pipeline: drop parser-generated UUID fields."""
-    if isinstance(val, dict):
-        out = dict(val)
-        out.pop("id", None)
-        out.pop("dual_group", None)
-        return {k: _strip_run_varying_ids(v) for k, v in out.items()}
-    if isinstance(val, list):
-        return [_strip_run_varying_ids(item) for item in val]
-    return val
-
-
 def _normalized_scene_for_digest(scene: dict, index: int) -> dict:
     """One scene dict normalized like parse scene checksum (no scene id)."""
     scene_copy = dict(scene)
     scene_copy.pop("id", None)
     scene_copy["_index"] = index
-    return _strip_run_varying_ids(scene_copy)
+    return strip_run_varying_ids(scene_copy)
 
 
 def scene_content_digest(scene: dict, index: int) -> str:
@@ -103,17 +93,21 @@ def _meta_counts(meta: dict[str, Any] | None) -> dict[str, int]:
         "other_locations_count",
     ):
         v = meta.get(key)
-        if isinstance(v, int):
-            out[key] = v
-        elif isinstance(v, bool):
+        if isinstance(v, bool):
             out[key] = int(v)
+        elif isinstance(v, int):
+            out[key] = v
         else:
             out[key] = 0
     elements = meta.get("elements")
     if isinstance(elements, dict):
         for ek, ev in elements.items():
-            if isinstance(ev, int):
+            if isinstance(ev, bool):
+                out[f"elements.{ek}"] = int(ev)
+            elif isinstance(ev, int):
                 out[f"elements.{ek}"] = ev
+            else:
+                out[f"elements.{ek}"] = 0
     return out
 
 

--- a/schoonmaker/parse_json_diff.py
+++ b/schoonmaker/parse_json_diff.py
@@ -64,7 +64,13 @@ def scene_digests(data: dict[str, Any]) -> list[str]:
 
 
 def _meta_counts(meta: dict[str, Any] | None) -> dict[str, int]:
-    """Flat word and element totals from metadata (0 if missing)."""
+    """
+    Flat totals from ``compute_screenplay_metadata`` output (0 if missing).
+
+    Word keys match metadata: action, dialogue, scene headings, and
+    parentheticals only (transition/shot/general/lyric words roll into
+    ``total_words`` but are not exposed separately there).
+    """
     if not meta:
         return {}
     out: dict[str, int] = {}
@@ -73,10 +79,6 @@ def _meta_counts(meta: dict[str, Any] | None) -> dict[str, int]:
         "total_action_words",
         "total_dialogue_words",
         "total_scene_heading_words",
-        "total_transition_words",
-        "total_shot_words",
-        "total_general_words",
-        "total_lyric_words",
         "total_parenthetical_words",
         "total_parenthetical_count",
         "total_dialogue_line_count",

--- a/schoonmaker/parse_json_diff.py
+++ b/schoonmaker/parse_json_diff.py
@@ -1,0 +1,386 @@
+"""Compare two schoonmaker parse JSON docs (e.g. same script, two saves)."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from pathlib import Path
+from typing import Any
+
+
+DIFF_REPORT_VERSION = 1
+
+
+def load_parse_json(path: str | Path) -> dict[str, Any]:
+    """Load a JSON file produced by ``cli.py parse``."""
+    p = Path(path)
+    text = p.read_text(encoding="utf-8")
+    data = json.loads(text)
+    if not isinstance(data, dict):
+        raise ValueError(f"parse JSON must be an object: {p}")
+    return data
+
+
+def _strip_run_varying_ids(val: object) -> object:
+    """Match checksum pipeline: drop parser-generated UUID fields."""
+    if isinstance(val, dict):
+        out = dict(val)
+        out.pop("id", None)
+        out.pop("dual_group", None)
+        return {k: _strip_run_varying_ids(v) for k, v in out.items()}
+    if isinstance(val, list):
+        return [_strip_run_varying_ids(item) for item in val]
+    return val
+
+
+def _normalized_scene_for_digest(scene: dict, index: int) -> dict:
+    """One scene dict normalized like parse scene checksum (no scene id)."""
+    scene_copy = dict(scene)
+    scene_copy.pop("id", None)
+    scene_copy["_index"] = index
+    return _strip_run_varying_ids(scene_copy)
+
+
+def scene_content_digest(scene: dict, index: int) -> str:
+    """SHA-256 hex for one scene (same rules as parse ``scene_checksums``)."""
+    normalized = _normalized_scene_for_digest(scene, index)
+    canonical = json.dumps(normalized, sort_keys=True, ensure_ascii=False)
+    return hashlib.sha256(canonical.encode("utf-8")).hexdigest()
+
+
+def scene_digests(data: dict[str, Any]) -> list[str]:
+    """
+    Per-scene content digests (always recomputed from ``scenes``).
+
+    Ignores ``checksums.scene_checksums`` so edited JSON cannot carry stale
+    per-scene hashes. Matches parse checksums when the document is unchanged.
+    """
+    scenes = data.get("scenes")
+    if not isinstance(scenes, list):
+        return []
+    digests: list[str] = []
+    for i, s in enumerate(scenes):
+        if isinstance(s, dict):
+            digests.append(scene_content_digest(s, i))
+        else:
+            digests.append(
+                hashlib.sha256(
+                    json.dumps({"_bad_scene": i}, sort_keys=True).encode(
+                        "utf-8"
+                    )
+                ).hexdigest()
+            )
+    return digests
+
+
+def _meta_counts(meta: dict[str, Any] | None) -> dict[str, int]:
+    """Flat word and element totals from metadata (0 if missing)."""
+    if not meta:
+        return {}
+    out: dict[str, int] = {}
+    for key in (
+        "total_words",
+        "total_action_words",
+        "total_dialogue_words",
+        "total_scene_heading_words",
+        "total_transition_words",
+        "total_shot_words",
+        "total_general_words",
+        "total_lyric_words",
+        "total_parenthetical_words",
+        "total_parenthetical_count",
+        "total_dialogue_line_count",
+        "total_action_count",
+        "total_dialogue_block_count",
+        "total_paragraphs_count",
+        "scenes_count",
+        "indoor_scenes_count",
+        "outdoor_scenes_count",
+        "other_scenes_count",
+        "total_locations_count",
+        "indoor_locations_count",
+        "outdoor_locations_count",
+        "other_locations_count",
+    ):
+        v = meta.get(key)
+        if isinstance(v, int):
+            out[key] = v
+        elif isinstance(v, bool):
+            out[key] = int(v)
+        else:
+            out[key] = 0
+    elements = meta.get("elements")
+    if isinstance(elements, dict):
+        for ek, ev in elements.items():
+            if isinstance(ev, int):
+                out[f"elements.{ek}"] = ev
+    return out
+
+
+def _location_list_to_map(rows: object) -> dict[str, int]:
+    if not isinstance(rows, list):
+        return {}
+    out: dict[str, int] = {}
+    for row in rows:
+        if isinstance(row, dict) and "location" in row:
+            loc = str(row["location"])
+            cnt = row.get("count", 0)
+            out[loc] = int(cnt) if isinstance(cnt, (int, float)) else 0
+    return out
+
+
+def _summarize_input(label: str, data: dict[str, Any]) -> dict[str, Any]:
+    out: dict[str, Any] = {"label": label}
+    out["parser_version"] = data.get("parser_version")
+    out["parse_datetime"] = data.get("parse_datetime")
+    out["nonce"] = data.get("nonce")
+    sf = data.get("source_file")
+    if isinstance(sf, dict):
+        out["source_file"] = {
+            "path_resolved": sf.get("path_resolved"),
+            "path_as_given": sf.get("path_as_given"),
+            "name": sf.get("name"),
+            "modified": sf.get("modified"),
+        }
+    return out
+
+
+def build_diff_report(
+    a: dict[str, Any],
+    b: dict[str, Any],
+    *,
+    label_a: str = "a",
+    label_b: str = "b",
+) -> dict[str, Any]:
+    """
+    Build a structured diff report (JSON-serializable).
+
+    ``a`` is treated as the earlier / baseline document; ``b`` as the newer.
+    Prefer parse output with ``--metadata`` for full word, character, and
+    location stats. ``--checksum`` avoids recomputing per-scene digests when
+    lists match scene count.
+    """
+    warnings: list[str] = []
+    scenes_a = a.get("scenes")
+    scenes_b = b.get("scenes")
+    if not isinstance(scenes_a, list):
+        raise ValueError(f"{label_a}: missing or invalid 'scenes' array")
+    if not isinstance(scenes_b, list):
+        raise ValueError(f"{label_b}: missing or invalid 'scenes' array")
+
+    meta_a = a.get("metadata")
+    meta_b = b.get("metadata")
+    if not isinstance(meta_a, dict):
+        warnings.append(
+            f"{label_a} has no metadata; word/character/location stats "
+            "are limited or omitted"
+        )
+        meta_a = None
+    if not isinstance(meta_b, dict):
+        warnings.append(
+            f"{label_b} has no metadata; word/character/location stats "
+            "are limited or omitted"
+        )
+        meta_b = None
+    if (meta_a is None) != (meta_b is None):
+        warnings.append(
+            "Only one input has metadata; full word/character/location "
+            "comparison needs --metadata on both parse runs"
+        )
+
+    dig_a = scene_digests(a)
+    dig_b = scene_digests(b)
+    n_a, n_b = len(scenes_a), len(scenes_b)
+    n_min = min(n_a, n_b)
+    changed_indices: list[int] = []
+    for i in range(n_min):
+        if i < len(dig_a) and i < len(dig_b) and dig_a[i] != dig_b[i]:
+            changed_indices.append(i)
+    added_scene_indices = list(range(n_a, n_b))
+    removed_scene_indices = list(range(n_b, n_a))
+
+    report: dict[str, Any] = {
+        "diff_version": DIFF_REPORT_VERSION,
+        "input": {
+            label_a: _summarize_input(label_a, a),
+            label_b: _summarize_input(label_b, b),
+        },
+        "scenes": {
+            "count_before": n_a,
+            "count_after": n_b,
+            "added_count": max(0, n_b - n_a),
+            "removed_count": max(0, n_a - n_b),
+            "added_scene_indices": added_scene_indices,
+            "removed_scene_indices": removed_scene_indices,
+            "changed_indices": changed_indices,
+            "unchanged_shared_count": n_min - len(changed_indices),
+        },
+        "warnings": warnings,
+    }
+
+    ca = _meta_counts(meta_a)
+    cb = _meta_counts(meta_b)
+    if meta_a is not None and meta_b is not None:
+        all_keys = sorted(set(ca) | set(cb))
+        words_detail: dict[str, Any] = {}
+        for key in all_keys:
+            va, vb = ca.get(key, 0), cb.get(key, 0)
+            if va or vb or key in ("total_words",):
+                words_detail[key] = {
+                    "before": va,
+                    "after": vb,
+                    "delta": vb - va,
+                }
+        report["counts"] = words_detail
+
+        # Element-type line-style summary (dialogue_line vs action etc.)
+        el_keys = [k for k in all_keys if k.startswith("elements.")]
+        report["elements"] = {
+            k: {
+                "before": ca.get(k, 0),
+                "after": cb.get(k, 0),
+                "delta": cb.get(k, 0) - ca.get(k, 0),
+            }
+            for k in sorted(el_keys)
+        }
+
+        chars_a = meta_a.get("characters") or {}
+        chars_b = meta_b.get("characters") or {}
+        if isinstance(chars_a, dict) and isinstance(chars_b, dict):
+            names_a = set(chars_a.keys())
+            names_b = set(chars_b.keys())
+            new_names = sorted(names_b - names_a)
+            gone_names = sorted(names_a - names_b)
+            both = sorted(names_a & names_b)
+            new_chars = []
+            for name in new_names:
+                row = chars_b.get(name)
+                if isinstance(row, dict):
+                    new_chars.append(
+                        {
+                            "name": name,
+                            "dialogue_lines": row.get(
+                                "dialogue_lines_count", 0
+                            ),
+                            "scenes_count": row.get("scenes_count", 0),
+                        }
+                    )
+            removed_chars = []
+            for name in gone_names:
+                row = chars_a.get(name)
+                if isinstance(row, dict):
+                    removed_chars.append(
+                        {
+                            "name": name,
+                            "dialogue_lines": row.get(
+                                "dialogue_lines_count", 0
+                            ),
+                            "scenes_count": row.get("scenes_count", 0),
+                        }
+                    )
+            line_changes = []
+            for name in both:
+                ra = chars_a.get(name) or {}
+                rb = chars_b.get(name) or {}
+                la = (
+                    ra.get("dialogue_lines_count", 0)
+                    if isinstance(ra, dict)
+                    else 0
+                )
+                lb = (
+                    rb.get("dialogue_lines_count", 0)
+                    if isinstance(rb, dict)
+                    else 0
+                )
+                sa = ra.get("scenes_count", 0) if isinstance(ra, dict) else 0
+                sb = rb.get("scenes_count", 0) if isinstance(rb, dict) else 0
+                if la != lb or sa != sb:
+                    line_changes.append(
+                        {
+                            "name": name,
+                            "dialogue_lines_before": la,
+                            "dialogue_lines_after": lb,
+                            "dialogue_lines_delta": lb - la,
+                            "scenes_count_before": sa,
+                            "scenes_count_after": sb,
+                            "scenes_count_delta": sb - sa,
+                        }
+                    )
+            report["characters"] = {
+                "new": new_chars,
+                "removed": removed_chars,
+                "changed": line_changes,
+            }
+
+        def loc_diff(
+            key: str,
+        ) -> dict[str, Any]:
+            ma = _location_list_to_map(meta_a.get(key))
+            mb = _location_list_to_map(meta_b.get(key))
+            keys = sorted(set(ma) | set(mb))
+            rows = []
+            for loc in keys:
+                va, vb = ma.get(loc, 0), mb.get(loc, 0)
+                if va != vb:
+                    rows.append(
+                        {
+                            "location": loc,
+                            "scene_count_before": va,
+                            "scene_count_after": vb,
+                            "delta": vb - va,
+                        }
+                    )
+            return {"key": key, "changed": rows}
+
+        report["locations"] = {
+            "summary": {
+                "total_locations_count": {
+                    "before": meta_a.get("total_locations_count", 0),
+                    "after": meta_b.get("total_locations_count", 0),
+                    "delta": meta_b.get("total_locations_count", 0)
+                    - meta_a.get("total_locations_count", 0),
+                },
+                "indoor_scenes_count": {
+                    "before": meta_a.get("indoor_scenes_count", 0),
+                    "after": meta_b.get("indoor_scenes_count", 0),
+                    "delta": meta_b.get("indoor_scenes_count", 0)
+                    - meta_a.get("indoor_scenes_count", 0),
+                },
+                "outdoor_scenes_count": {
+                    "before": meta_a.get("outdoor_scenes_count", 0),
+                    "after": meta_b.get("outdoor_scenes_count", 0),
+                    "delta": meta_b.get("outdoor_scenes_count", 0)
+                    - meta_a.get("outdoor_scenes_count", 0),
+                },
+                "other_scenes_count": {
+                    "before": meta_a.get("other_scenes_count", 0),
+                    "after": meta_b.get("other_scenes_count", 0),
+                    "delta": meta_b.get("other_scenes_count", 0)
+                    - meta_a.get("other_scenes_count", 0),
+                },
+            },
+            "by_bucket": [
+                loc_diff("locations"),
+                loc_diff("indoor_locations"),
+                loc_diff("outdoor_locations"),
+                loc_diff("other_locations"),
+            ],
+        }
+    else:
+        report["counts"] = {}
+        report["elements"] = {}
+        report["characters"] = {
+            "new": [],
+            "removed": [],
+            "changed": [],
+        }
+        report["locations"] = {
+            "summary": {},
+            "by_bucket": [],
+        }
+
+    return report
+
+
+def diff_report_to_json(report: dict[str, Any], *, indent: int = 2) -> str:
+    return json.dumps(report, indent=indent, ensure_ascii=False) + "\n"

--- a/schoonmaker/utils.py
+++ b/schoonmaker/utils.py
@@ -1,6 +1,23 @@
 import logging
 
 
+def strip_run_varying_ids(val: object) -> object:
+    """
+    Recursively remove ``id`` and ``dual_group`` from dicts.
+
+    Used by parse checksums and by ``parse_json_diff`` scene digests so both
+    stay aligned.
+    """
+    if isinstance(val, dict):
+        out = dict(val)
+        out.pop("id", None)
+        out.pop("dual_group", None)
+        return {k: strip_run_varying_ids(v) for k, v in out.items()}
+    if isinstance(val, list):
+        return [strip_run_varying_ids(item) for item in val]
+    return val
+
+
 def set_up_logging(level=logging.DEBUG):
     format = "[%(levelname)s] %(asctime)s %(message)s"
     logging.basicConfig(format=format, level=level)

--- a/schoonmaker/version.py
+++ b/schoonmaker/version.py
@@ -1,1 +1,1 @@
-version = "0.12.0"
+version = "1.0.0"

--- a/tests/test_cli_args.py
+++ b/tests/test_cli_args.py
@@ -44,3 +44,12 @@ class TestCLIArgs(unittest.TestCase):
         self.assertTrue(args.metadata)
         self.assertTrue(args.checksum)
         self.assertTrue(args.file_info)
+
+    def test_diff_before_after_short_flags(self):
+        args = CLIArgParser().parser.parse_args(
+            ["diff", "-a", "old.json", "-b", "new.json", "-o", "out.json"]
+        )
+        self.assertEqual(args.command, "diff")
+        self.assertEqual(args.before, "old.json")
+        self.assertEqual(args.after, "new.json")
+        self.assertEqual(args.output, "out.json")

--- a/tests/test_cli_args.py
+++ b/tests/test_cli_args.py
@@ -47,7 +47,7 @@ class TestCLIArgs(unittest.TestCase):
 
     def test_diff_before_after_short_flags(self):
         args = CLIArgParser().parser.parse_args(
-            ["diff", "-a", "old.json", "-b", "new.json", "-o", "out.json"]
+            ["diff", "-b", "old.json", "-a", "new.json", "-o", "out.json"]
         )
         self.assertEqual(args.command, "diff")
         self.assertEqual(args.before, "old.json")

--- a/tests/test_parse_json_diff.py
+++ b/tests/test_parse_json_diff.py
@@ -1,0 +1,162 @@
+"""Tests for parse JSON diff (cli.py diff)."""
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+from schoonmaker.parse_json_diff import (
+    build_diff_report,
+    load_parse_json,
+    scene_content_digest,
+    scene_digests,
+)
+
+
+def _run_parse_json(out_path, fdx_path, **flags):
+    from cli import run_parse
+
+    a = type(
+        "Args",
+        (),
+        {
+            "command": "parse",
+            "file": str(fdx_path),
+            "output": str(out_path),
+            "metadata": flags.get("metadata", False),
+            "checksum": flags.get("checksum", False),
+            "file_info": flags.get("file_info", False),
+        },
+    )()
+    run_parse(a)
+
+
+def test_scene_digest_matches_parse_scene_checksums(sample_fdx_path, tmp_path):
+    """Recomputed scene digests match parse output when --checksum is used."""
+    out = tmp_path / "p.json"
+    _run_parse_json(out, sample_fdx_path, metadata=True, checksum=True)
+    data = json.loads(out.read_text(encoding="utf-8"))
+    scenes = data["scenes"]
+    stored = data["checksums"]["scene_checksums"]
+    for i, scene in enumerate(scenes):
+        assert scene_content_digest(scene, i) == stored[i]
+
+
+def test_diff_identical_documents_empty_delta(sample_fdx_path, tmp_path):
+    """Two parses of the same FDX show no scene or word deltas."""
+    ja = tmp_path / "a.json"
+    jb = tmp_path / "b.json"
+    _run_parse_json(ja, sample_fdx_path, metadata=True, checksum=True)
+    _run_parse_json(jb, sample_fdx_path, metadata=True, checksum=True)
+    r = build_diff_report(
+        load_parse_json(ja),
+        load_parse_json(jb),
+    )
+    assert r["scenes"]["changed_indices"] == []
+    assert r["scenes"]["added_count"] == 0
+    assert r["scenes"]["removed_count"] == 0
+    assert r["counts"]["total_words"]["delta"] == 0
+    assert r["characters"]["new"] == []
+    assert r["characters"]["removed"] == []
+
+
+def test_diff_detects_scene_heading_change(sample_fdx_path, tmp_path):
+    """Mutating one scene heading yields that index in changed_indices."""
+    ja = tmp_path / "a.json"
+    jb = tmp_path / "b.json"
+    _run_parse_json(ja, sample_fdx_path, metadata=True, checksum=True)
+    data = json.loads(ja.read_text(encoding="utf-8"))
+    data["scenes"][0]["heading"]["raw"] = "INT. CHANGED LOCATION - DAY"
+    jb.write_text(
+        json.dumps(data, indent=2, ensure_ascii=False) + "\n",
+        encoding="utf-8",
+    )
+    r = build_diff_report(
+        load_parse_json(ja),
+        load_parse_json(jb),
+    )
+    assert 0 in r["scenes"]["changed_indices"]
+
+
+def test_diff_added_scene_in_after(sample_fdx_path, tmp_path):
+    """Extra scene in ``after`` increases count and marks new tail index."""
+    ja = tmp_path / "a.json"
+    jb = tmp_path / "b.json"
+    _run_parse_json(ja, sample_fdx_path, metadata=True, checksum=True)
+    data = json.loads(ja.read_text(encoding="utf-8"))
+    dup = json.loads(json.dumps(data["scenes"][-1]))
+    data["scenes"].append(dup)
+    if "metadata" in data:
+        del data["metadata"]
+    if "checksums" in data:
+        del data["checksums"]
+    jb.write_text(
+        json.dumps(data, indent=2, ensure_ascii=False) + "\n",
+        encoding="utf-8",
+    )
+    r = build_diff_report(load_parse_json(ja), load_parse_json(jb))
+    assert r["scenes"]["added_count"] == 1
+    assert r["scenes"]["removed_count"] == 0
+    n_before = r["scenes"]["count_before"]
+    assert n_before + 1 == r["scenes"]["count_after"]
+
+
+def test_diff_without_metadata_warns(sample_fdx_path, tmp_path):
+    ja = tmp_path / "a.json"
+    jb = tmp_path / "b.json"
+    _run_parse_json(ja, sample_fdx_path, metadata=False, checksum=True)
+    _run_parse_json(jb, sample_fdx_path, metadata=False, checksum=True)
+    r = build_diff_report(load_parse_json(ja), load_parse_json(jb))
+    assert any("metadata" in w.lower() for w in r["warnings"])
+    assert r["counts"] == {}
+
+
+def test_load_parse_json_invalid(tmp_path):
+    bad = tmp_path / "bad.json"
+    bad.write_text("[1,2,3]", encoding="utf-8")
+    with pytest.raises(ValueError, match="object"):
+        load_parse_json(bad)
+
+
+def test_cli_diff_subprocess(sample_fdx_path, tmp_path):
+    repo = Path(__file__).resolve().parent.parent
+    cli = repo / "cli.py"
+    ja = tmp_path / "a.json"
+    jb = tmp_path / "b.json"
+    out = tmp_path / "diff.json"
+    _run_parse_json(ja, sample_fdx_path, metadata=True, checksum=True)
+    _run_parse_json(jb, sample_fdx_path, metadata=True, checksum=True)
+    proc = subprocess.run(
+        [
+            sys.executable,
+            str(cli),
+            "diff",
+            "--before",
+            str(ja),
+            "--after",
+            str(jb),
+            "-o",
+            str(out),
+        ],
+        cwd=str(repo),
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    assert proc.stdout == ""
+    report = json.loads(out.read_text(encoding="utf-8"))
+    assert report["diff_version"] == 1
+    assert report["scenes"]["changed_indices"] == []
+
+
+def test_scene_digests_ignore_removed_checksums(sample_fdx_path, tmp_path):
+    """Recomputation is identical with or without ``checksums`` in the JSON."""
+    out = tmp_path / "p.json"
+    _run_parse_json(out, sample_fdx_path, metadata=False, checksum=True)
+    data = json.loads(out.read_text(encoding="utf-8"))
+    d1 = scene_digests(data)
+    del data["checksums"]
+    d2 = scene_digests(data)
+    assert d1 == d2


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Adds a new `diff` command and a non-trivial diff-report generator that interprets parse JSON/metadata, so correctness depends on JSON shape and digest normalization staying aligned with `parse --checksum` output.
> 
> **Overview**
> Adds a new `cli.py diff` subcommand to compare two `parse` JSON snapshots and emit a structured JSON report including scene-level change detection (via recomputed per-scene digests), plus optional word/element/character/location deltas when both inputs include `--metadata`.
> 
> Extracts shared normalization into `utils.strip_run_varying_ids` to keep checksum and diff digest rules consistent, introduces `schoonmaker/parse_json_diff.py` as the diff engine, updates docs/tests accordingly, and bumps `schoonmaker.version` to `1.0.0`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 52fa3fd447eb4c38e4e06d6b4034e2fa61a114e0. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->