### PR TITLE
Add storyboard and beat board parsing

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -63,6 +63,12 @@ schoonmaker parse -f path/to/script.fdx -o script.json --checksum
 # Include source file path, size, and timestamps in JSON
 schoonmaker parse -f path/to/script.fdx -o script.json --file-info
 
+# Include <ListItems> beat board in JSON (excluded from --metadata script totals)
+schoonmaker parse -f path/to/script.fdx -o script.json --list-items
+
+# Include <DisplayBoards> Story Map / Beat layout (excluded from --metadata totals)
+schoonmaker parse -f path/to/script.fdx -o script.json --display-boards
+
 # All optional parse flags together (metadata, checksums, source file stats)
 schoonmaker parse -f path/to/script.fdx -o script.json \
   --metadata --checksum --file-info
@@ -73,6 +79,9 @@ schoonmaker diff -b older.json -a newer.json -o report.json
 
 # Changed .fdx between two git commits (CI); optional env CI_FDX_BASE_SHA / CI_FDX_HEAD_SHA
 schoonmaker ci-fdx-diff -o fdx-reports --base-sha "$BASE" --head-sha "$HEAD"
+
+# Same with beat-board parse extras (or set CI_FDX_LIST_ITEMS / CI_FDX_DISPLAY_BOARDS)
+schoonmaker ci-fdx-diff -o fdx-reports --list-items --display-boards
 
 # Emit FDX → Fountain to stdout
 schoonmaker fountain -f path/to/script.fdx

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -17,6 +17,7 @@ This repo is a **Python tool** for working with Final Draft `.fdx` screenplay fi
   - **`source_file_info.py`** – `source_file_info(path)` for optional `parse --file-info` JSON (`path_resolved`, `size_bytes`, timestamps).
   - **`parse_json_diff.py`** – `build_diff_report`, `load_parse_json`, `scene_digests` for `schoonmaker diff`.
   - **`ci_fdx_diff.py`** – `run_ci_fdx_diff`, `resolve_base_sha`, etc. for `schoonmaker ci-fdx-diff` (git + parse + diff).
+  - **`ci_report_md.py`** – `markdown_from_ci_reports` for `schoonmaker ci-report-md` (GitHub Step Summary).
   - **`utils.py`** – Logging helpers; `strip_run_varying_ids` (shared checksum / diff normalization).
 - **`cli.py`** (repo root) – Thin shim calling `schoonmaker.cli:main` so **`python cli.py`** still works from a clone without installing.
 - **`tests/`** – Unified test suite (pytest). **`tests/fixtures/`** – FDX and other test fixtures (e.g. `sample.fdx`).
@@ -82,6 +83,9 @@ schoonmaker ci-fdx-diff -o fdx-reports --base-sha "$BASE" --head-sha "$HEAD"
 
 # Same with beat-board parse extras (or set CI_FDX_LIST_ITEMS / CI_FDX_DISPLAY_BOARDS)
 schoonmaker ci-fdx-diff -o fdx-reports --list-items --display-boards
+
+# Markdown summary of ci-fdx-diff output (append to GITHUB_STEP_SUMMARY in Actions)
+schoonmaker ci-report-md fdx-reports
 
 # Emit FDX → Fountain to stdout
 schoonmaker fountain -f path/to/script.fdx

--- a/README.md
+++ b/README.md
@@ -54,6 +54,12 @@ schoonmaker parse -f path/to/script.fdx -o script.json --checksum
 # Include source file path, size, and filesystem timestamps in the JSON
 schoonmaker parse -f path/to/script.fdx -o script.json --file-info
 
+# Include Final Draft beat/outline <ListItems> in JSON (not counted in --metadata totals)
+schoonmaker parse -f path/to/script.fdx -o script.json --list-items
+
+# Include <DisplayBoards> (Story Map / Beat canvas layout); also excluded from --metadata totals
+schoonmaker parse -f path/to/script.fdx -o script.json --display-boards
+
 # All optional parse flags together (metadata, checksums, source file stats)
 schoonmaker parse -f path/to/script.fdx -o script.json \
   --metadata --checksum --file-info
@@ -94,6 +100,6 @@ Copy **`examples/requirements-ci.txt`** to the other repo root. Add **`examples/
 
 Parse JSON output always includes **`nonce`** (unique per run), **`parser_version`** (from `schoonmaker.version`), and **`parse_datetime`** (UTC ISO). With **`--checksum`**, a **`checksums`** object is added with SHA-256 hashes for `alt_collection`, `scenes`, `title_page`, and `preamble` (each is the hash of canonical JSON of that section after normalizing away run-varying IDs). **`scene_checksums`** is a parallel list of SHA-256 digests, one per scene in order, so a diff can show which scene indices changed without re-parsing the full `scenes` array. With **`--file-info`**, a **`source_file`** object records the input path (as given and resolved), basename, **`size_bytes`**, and UTC ISO **`modified`** / **`accessed`** times; **`created`** is included when the OS exposes it (e.g. Windows, macOS).
 
-The **`diff`** subcommand reads two parse JSON files and writes a report with **`scenes`** (counts, **`changed_indices`**, **`added_scene_indices`**, **`removed_scene_indices`**), **`counts`** (word and paragraph totals with before/after/delta), **`elements`** (action, dialogue lines, etc.), **`characters`** (new, removed, line/scene deltas), and **`locations`** (summary and per-location scene-count changes). Pass **`--metadata`** when generating both JSON files for full stats; scene-level changes are always derived from **`scenes`** using the same digest rules as parse checksums (stale **`scene_checksums`** in hand-edited JSON are not trusted).
+The **`diff`** subcommand reads two parse JSON files and writes a report with **`scenes`** (counts, **`changed_indices`**, **`added_scene_indices`**, **`removed_scene_indices`**), **`counts`** (word and paragraph totals with before/after/delta), **`elements`** (action, dialogue lines, etc.), **`characters`** (new, removed, line/scene deltas), and **`locations`** (summary and per-location scene-count changes). If either input includes non-empty **`list_items`** or **`display_boards`** (from **`parse --list-items`** / **`--display-boards`**), the report adds a short summary (**counts**, SHA-256 **digests**, **`changed`**). Pass **`--metadata`** when generating both JSON files for full stats; scene-level changes are always derived from **`scenes`** using the same digest rules as parse checksums (stale **`scene_checksums`** in hand-edited JSON are not trusted).
 
 See **AGENTS.md** for layout, conventions, and full command reference.

--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ docker compose build && docker compose run --rm schoonmaker
 
 ### Using this repo from another project (GitHub Actions)
 
-Use **`schoonmaker ci-fdx-diff`** in the workflow (see **`examples/`**), or hand-roll: **`git diff`** the base and head SHAs for changed `*.fdx` paths, **`schoonmaker parse --metadata --checksum`** each side, then **`schoonmaker diff`**; upload JSON as **artifacts** or summarize with `jq`/Python.
+Use **`schoonmaker ci-fdx-diff`** in the workflow (see **`examples/`**), or hand-roll: **`git diff`** the base and head SHAs for changed `*.fdx` paths, **`schoonmaker parse --metadata --checksum`** each side, then **`schoonmaker diff`**; upload JSON as **artifacts**. Append **`schoonmaker ci-report-md fdx-reports >> "$GITHUB_STEP_SUMMARY"`** so the workflow run shows a Markdown summary (scene/word deltas per file) on GitHub.
 
 Copy **`examples/requirements-ci.txt`** to the other repo root. Add **`examples/github-actions-fdx-changes-pr.yml`** to **`.github/workflows/`** for pull requests. Optionally add **`examples/github-actions-fdx-changes-push.yml`** for pushes to `main`. See **`examples/README.md`**. Edit **`requirements-ci.txt`** (**pin a tag or commit**, replace `YOUR_ORG`). For private repos, use a [`pip` URL with a token](https://pip.pypa.io/en/stable/topics/authentication/) or vendor a wheel.
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -11,4 +11,6 @@ Use one or both. For PR review, **`pr`** is usually enough; **`push`** is for po
 
 **Beat board in CI:** To include `<ListItems>` / `<DisplayBoards>` in the artifact JSON and in each `*-diff.json` summary, set **`CI_FDX_LIST_ITEMS`** / **`CI_FDX_DISPLAY_BOARDS`** to **`1`**, **`true`**, **`yes`**, or **`on`**, and/or pass **`--list-items`** / **`--display-boards`** on **`ci-fdx-diff`**. CLI and env are OR’d (either enables the option).
 
+**Job summary in the GitHub UI:** The example workflows append Markdown to **`GITHUB_STEP_SUMMARY`** via **`schoonmaker ci-report-md fdx-reports`**, so the workflow run page shows tables for scene/word deltas per changed script. For pull requests, a [**sticky PR comment**](https://github.com/marocchino/sticky-pull-request-comment) or **`actions/github-script`** can post the same Markdown on the PR for visibility (needs `pull-requests: write`).
+
 There is no cron example in the repo: add your own if you need it.

--- a/examples/README.md
+++ b/examples/README.md
@@ -9,4 +9,6 @@ Copy **`requirements-ci.txt`** to the root of your repo and set **org + tag** fo
 
 Use one or both. For PR review, **`pr`** is usually enough; **`push`** is for post-merge analysis.
 
+**Beat board in CI:** To include `<ListItems>` / `<DisplayBoards>` in the artifact JSON and in each `*-diff.json` summary, set **`CI_FDX_LIST_ITEMS`** / **`CI_FDX_DISPLAY_BOARDS`** to **`1`**, **`true`**, **`yes`**, or **`on`**, and/or pass **`--list-items`** / **`--display-boards`** on **`ci-fdx-diff`**. CLI and env are OR’d (either enables the option).
+
 There is no cron example in the repo: add your own if you need it.

--- a/examples/github-actions-fdx-changes-pr.yml
+++ b/examples/github-actions-fdx-changes-pr.yml
@@ -32,6 +32,8 @@ jobs:
         env:
           CI_FDX_BASE_SHA: ${{ github.event.pull_request.base.sha }}
           CI_FDX_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          # Optional: CI_FDX_LIST_ITEMS / CI_FDX_DISPLAY_BOARDS = 1, true, yes, on
+          # or add --list-items / --display-boards to the run command.
         run: schoonmaker ci-fdx-diff -o fdx-reports
 
       - uses: actions/upload-artifact@v4

--- a/examples/github-actions-fdx-changes-pr.yml
+++ b/examples/github-actions-fdx-changes-pr.yml
@@ -36,6 +36,10 @@ jobs:
           # or add --list-items / --display-boards to the run command.
         run: schoonmaker ci-fdx-diff -o fdx-reports
 
+      - name: Add FDX report to GitHub job summary
+        if: always()
+        run: schoonmaker ci-report-md fdx-reports >> "$GITHUB_STEP_SUMMARY"
+
       - uses: actions/upload-artifact@v4
         if: always()
         with:

--- a/examples/github-actions-fdx-changes-push.yml
+++ b/examples/github-actions-fdx-changes-push.yml
@@ -36,6 +36,8 @@ jobs:
         env:
           CI_FDX_BASE_SHA: ${{ github.event.before }}
           CI_FDX_HEAD_SHA: ${{ github.event.after }}
+          # Optional: CI_FDX_LIST_ITEMS / CI_FDX_DISPLAY_BOARDS = 1, true, yes, on
+          # or add --list-items / --display-boards to the run command.
         run: schoonmaker ci-fdx-diff -o fdx-reports
 
       - uses: actions/upload-artifact@v4

--- a/examples/github-actions-fdx-changes-push.yml
+++ b/examples/github-actions-fdx-changes-push.yml
@@ -40,6 +40,10 @@ jobs:
           # or add --list-items / --display-boards to the run command.
         run: schoonmaker ci-fdx-diff -o fdx-reports
 
+      - name: Add FDX report to GitHub job summary
+        if: always()
+        run: schoonmaker ci-report-md fdx-reports >> "$GITHUB_STEP_SUMMARY"
+
       - uses: actions/upload-artifact@v4
         if: always()
         with:

--- a/schoonmaker/ci_fdx_diff.py
+++ b/schoonmaker/ci_fdx_diff.py
@@ -19,6 +19,11 @@ from types import SimpleNamespace
 _GIT_NULL_SHA = "0" * 40
 
 
+def _env_truthy(name: str) -> bool:
+    v = (os.environ.get(name) or "").strip().lower()
+    return v in ("1", "true", "yes", "on")
+
+
 def path_fingerprint(repo_relative_path: str) -> str:
     """Stable hex id for a repo path (like diff report artifact names)."""
     return hashlib.sha256(repo_relative_path.encode("utf-8")).hexdigest()
@@ -97,6 +102,8 @@ def run_ci_fdx_diff(
     head_sha: str,
     *,
     repo: Path | None = None,
+    list_items: bool = False,
+    display_boards: bool = False,
 ) -> int:
     """
     For each changed .fdx between base and head: parse both, write diff JSON.
@@ -142,6 +149,8 @@ def run_ci_fdx_diff(
             cwd,
             output_dir,
             tmp_root,
+            list_items=list_items,
+            display_boards=display_boards,
         )
     finally:
         if tmp_root.exists():
@@ -155,8 +164,23 @@ def _run_ci_fdx_diff_loop(
     cwd: Path | None,
     output_dir: Path,
     tmp_root: Path,
+    *,
+    list_items: bool = False,
+    display_boards: bool = False,
 ) -> int:
     from schoonmaker.cli import run_diff, run_parse
+
+    def _parse_ns(fdx: Path, json_out: Path) -> SimpleNamespace:
+        return SimpleNamespace(
+            command="parse",
+            file=str(fdx),
+            output=str(json_out),
+            metadata=True,
+            checksum=True,
+            file_info=False,
+            list_items=list_items,
+            display_boards=display_boards,
+        )
 
     index_path = output_dir / "path-index.tsv"
     for rel in paths:
@@ -196,28 +220,10 @@ def _run_ci_fdx_diff_loop(
         diff_out = output_dir / f"{safe}-diff.json"
 
         if has_before:
-            rc = run_parse(
-                SimpleNamespace(
-                    command="parse",
-                    file=str(before_fdx),
-                    output=str(before_json),
-                    metadata=True,
-                    checksum=True,
-                    file_info=False,
-                )
-            )
+            rc = run_parse(_parse_ns(before_fdx, before_json))
             if rc != 0:
                 return rc
-            rc = run_parse(
-                SimpleNamespace(
-                    command="parse",
-                    file=str(after_fdx),
-                    output=str(after_json),
-                    metadata=True,
-                    checksum=True,
-                    file_info=False,
-                )
-            )
+            rc = run_parse(_parse_ns(after_fdx, after_json))
             if rc != 0:
                 return rc
             rc = run_diff(
@@ -234,16 +240,7 @@ def _run_ci_fdx_diff_loop(
             new_note = output_dir / f"{safe}-new.txt"
             new_note.write_text(f"New file: {rel}\n", encoding="utf-8")
             parse_only = output_dir / f"{safe}-parse.json"
-            rc = run_parse(
-                SimpleNamespace(
-                    command="parse",
-                    file=str(after_fdx),
-                    output=str(parse_only),
-                    metadata=True,
-                    checksum=True,
-                    file_info=False,
-                )
-            )
+            rc = run_parse(_parse_ns(after_fdx, parse_only))
             if rc != 0:
                 return rc
 
@@ -263,4 +260,17 @@ def main_ci_fdx_diff(args: SimpleNamespace) -> int:
     repo = None
     if repo_arg is not None and str(repo_arg).strip():
         repo = Path(str(repo_arg)).resolve()
-    return run_ci_fdx_diff(out, base, head, repo=repo)
+    list_items = bool(getattr(args, "list_items", False)) or _env_truthy(
+        "CI_FDX_LIST_ITEMS"
+    )
+    display_boards = bool(
+        getattr(args, "display_boards", False)
+    ) or _env_truthy("CI_FDX_DISPLAY_BOARDS")
+    return run_ci_fdx_diff(
+        out,
+        base,
+        head,
+        repo=repo,
+        list_items=list_items,
+        display_boards=display_boards,
+    )

--- a/schoonmaker/ci_report_md.py
+++ b/schoonmaker/ci_report_md.py
@@ -1,0 +1,175 @@
+"""Markdown from ``ci-fdx-diff`` reports for GitHub Actions Step Summary."""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+
+def _load_path_index(reports_dir: Path) -> dict[str, str]:
+    """Map fingerprint to repo path using ``path-index.tsv`` columns."""
+    p = reports_dir / "path-index.tsv"
+    if not p.is_file():
+        return {}
+    out: dict[str, str] = {}
+    for line in p.read_text(encoding="utf-8").splitlines():
+        line = line.strip()
+        if not line or "\t" not in line:
+            continue
+        safe, rel = line.split("\t", 1)
+        safe, rel = safe.strip(), rel.strip()
+        if safe:
+            out[safe] = rel
+    return out
+
+
+def _safe_from_diff_name(path: Path) -> str:
+    """``ab12...-diff.json`` → ``ab12...``."""
+    name = path.name
+    if name.endswith("-diff.json"):
+        return name[: -len("-diff.json")]
+    return path.stem
+
+
+def _fmt_changed_indices(indices: list[int], *, limit: int = 24) -> str:
+    if not indices:
+        return "—"
+    if len(indices) <= limit:
+        return ", ".join(str(i) for i in indices)
+    head = ", ".join(str(i) for i in indices[:limit])
+    return f"{head}, … (+{len(indices) - limit} more)"
+
+
+def _render_one_diff(data: dict[str, Any], title: str) -> str:
+    lines: list[str] = []
+    lines.append(f"### {title}")
+    lines.append("")
+
+    sc = data.get("scenes") or {}
+    if isinstance(sc, dict):
+        lines.append("| (scenes) | Before | After | Δ |")
+        lines.append("| --- | ---: | ---: | ---: |")
+        cb, ca = sc.get("count_before"), sc.get("count_after")
+        delta_n = (ca or 0) - (cb or 0)
+        lines.append(f"| Scene count | {cb} | {ca} | {delta_n:+d} |")
+        changed_idx = sc.get("changed_indices") or []
+        if isinstance(changed_idx, list) and changed_idx:
+            nums = [int(x) for x in changed_idx if isinstance(x, (int, float))]
+            lines.append("")
+            cj = _fmt_changed_indices(nums)
+            lines.append(f"**Changed scene indices:** {cj}")
+        added = sc.get("added_scene_indices") or []
+        rem = sc.get("removed_scene_indices") or []
+        if (isinstance(added, list) and added) or (
+            isinstance(rem, list) and rem
+        ):
+            lines.append("")
+            if added:
+                add_nums = [
+                    int(x) for x in added if isinstance(x, (int, float))
+                ]
+                aj = _fmt_changed_indices(add_nums, limit=16)
+                lines.append(f"**Added scenes (indices):** {aj}")
+            if rem:
+                rem_nums = [int(x) for x in rem if isinstance(x, (int, float))]
+                rj = _fmt_changed_indices(rem_nums, limit=16)
+                lines.append(f"**Removed scenes (indices):** {rj}")
+
+    counts = data.get("counts") or {}
+    tw = counts.get("total_words") if isinstance(counts, dict) else None
+    if isinstance(tw, dict):
+        b, a, d = tw.get("before"), tw.get("after"), tw.get("delta")
+        lines.append("")
+        lines.append("| Words | Before | After | Δ |")
+        lines.append("| --- | ---: | ---: | ---: |")
+        if isinstance(d, int):
+            line = f"| Total | {b} | {a} | {d:+d} |"
+        else:
+            line = f"| Total | {b} | {a} | |"
+        lines.append(line)
+
+    chars = data.get("characters") or {}
+    if isinstance(chars, dict):
+        n_new = len(chars.get("new") or [])
+        n_gone = len(chars.get("removed") or [])
+        n_ch = len(chars.get("changed") or [])
+        if n_new or n_gone or n_ch:
+            lines.append("")
+            lines.append(
+                "**Characters:** "
+                f"{n_new} new, {n_gone} removed, {n_ch} changed"
+            )
+
+    for key in ("list_items", "display_boards"):
+        blk = data.get(key)
+        if isinstance(blk, dict) and blk:
+            chg = blk.get("changed")
+            cb, ca = blk.get("count_before"), blk.get("count_after")
+            lines.append("")
+            lines.append(
+                f"**{key}:** counts {cb} → {ca}"
+                + (
+                    f", **changed:** {'yes' if chg else 'no'}"
+                    if chg is not None
+                    else ""
+                )
+            )
+
+    warns = data.get("warnings") or []
+    if isinstance(warns, list) and warns:
+        lines.append("")
+        lines.append("**Warnings**")
+        for w in warns:
+            if isinstance(w, str) and w.strip():
+                lines.append(f"- {w.strip()}")
+
+    lines.append("")
+    return "\n".join(lines)
+
+
+def markdown_from_ci_reports(reports_dir: str | Path) -> str:
+    """
+    Build Markdown for GitHub Step Summary from ``*-diff.json`` files.
+
+    Uses ``path-index.tsv`` in the same directory to label each file with the
+    repo-relative ``.fdx`` path when present.
+    """
+    root = Path(reports_dir).resolve()
+    index = _load_path_index(root)
+    diff_files = sorted(root.glob("*-diff.json"))
+    if not diff_files:
+        return (
+            "## FDX diff report\n\n"
+            "_No `*-diff.json` files in this directory._\n"
+        )
+
+    parts: list[str] = ["## FDX diff report\n"]
+    for df in diff_files:
+        try:
+            data = json.loads(df.read_text(encoding="utf-8"))
+        except (OSError, json.JSONDecodeError) as e:
+            parts.append(f"### {df.name}\n\n_Parse error: {e}_\n\n")
+            continue
+        if not isinstance(data, dict):
+            parts.append(f"### {df.name}\n\n_Invalid JSON root._\n\n")
+            continue
+        safe = _safe_from_diff_name(df)
+        title = index.get(safe) or df.name
+        parts.append(_render_one_diff(data, title))
+    return "".join(parts)
+
+
+def main_ci_report_md(args: Any) -> int:
+    """CLI entry for ``ci-report-md``."""
+    d = getattr(args, "reports_dir", None) or "."
+    md = markdown_from_ci_reports(d)
+    out = getattr(args, "output", None)
+    if out:
+        Path(out).write_text(md, encoding="utf-8")
+    else:
+        sys.stdout.write(md)
+        if not md.endswith("\n"):
+            sys.stdout.write("\n")
+    return 0

--- a/schoonmaker/cli.py
+++ b/schoonmaker/cli.py
@@ -186,6 +186,10 @@ def main() -> int:
         from schoonmaker.ci_fdx_diff import main_ci_fdx_diff
 
         return main_ci_fdx_diff(args)
+    if args.command == "ci-report-md":
+        from schoonmaker.ci_report_md import main_ci_report_md
+
+        return main_ci_report_md(args)
 
     log.error("Unknown command: %s", args.command)
     return 2

--- a/schoonmaker/cli.py
+++ b/schoonmaker/cli.py
@@ -130,7 +130,10 @@ def _compute_output_checksums(out: dict) -> dict[str, object]:
 
 
 def run_parse(args) -> int:
-    screenplay = FDXParser().parse(args.file)
+    screenplay = FDXParser(
+        include_list_items=getattr(args, "list_items", False),
+        include_display_boards=getattr(args, "display_boards", False),
+    ).parse(args.file)
     out = {
         "nonce": uuid.uuid4().hex,
         "parser_version": parser_version,

--- a/schoonmaker/cli_arg_parser.py
+++ b/schoonmaker/cli_arg_parser.py
@@ -10,8 +10,8 @@ class CLIArgParser(object):
         self.parser = ArgumentParser(
             prog="schoonmaker",
             description=(
-                "Parse FDX; export JSON AST or Fountain; "
-                "diff parse JSON snapshots or changed .fdx in git (CI)."
+                "Parse FDX; export JSON AST or Fountain; diff parse JSON "
+                "or CI reports; Markdown for GitHub Actions Step Summary."
             ),
         )
         subparsers = self.parser.add_subparsers(dest="command", required=True)
@@ -170,6 +170,26 @@ class CLIArgParser(object):
             ),
         )
         ci_parser.set_defaults(command="ci-fdx-diff")
+
+        report_md_parser = subparsers.add_parser(
+            "ci-report-md",
+            help=(
+                "Emit Markdown from ci-fdx-diff *-diff.json (GitHub Summary)"
+            ),
+        )
+        report_md_parser.add_argument(
+            "reports_dir",
+            nargs="?",
+            default=".",
+            help="Directory with *-diff.json and optional path-index.tsv",
+        )
+        report_md_parser.add_argument(
+            "-o",
+            "--output",
+            type=str,
+            help="Write Markdown here (default: stdout)",
+        )
+        report_md_parser.set_defaults(command="ci-report-md")
 
     def _parse_args(self) -> Namespace:
         return self.parser.parse_args()

--- a/schoonmaker/cli_arg_parser.py
+++ b/schoonmaker/cli_arg_parser.py
@@ -57,6 +57,24 @@ class CLIArgParser(object):
             dest="file_info",
             help="Include source file path, size, and timestamps in JSON",
         )
+        parse_parser.add_argument(
+            "--list-items",
+            action="store_true",
+            dest="list_items",
+            help=(
+                "Include Final Draft <ListItems> (beat/outline board) in "
+                "JSON; excluded from --metadata script totals"
+            ),
+        )
+        parse_parser.add_argument(
+            "--display-boards",
+            action="store_true",
+            dest="display_boards",
+            help=(
+                "Include Final Draft <DisplayBoards> (Story Map / Beat "
+                "layout) in JSON; excluded from --metadata script totals"
+            ),
+        )
         parse_parser.set_defaults(command="parse")
 
         fountain_parser = subparsers.add_parser(
@@ -132,6 +150,24 @@ class CLIArgParser(object):
             type=str,
             default="",
             help="Git repository root (default: current directory)",
+        )
+        ci_parser.add_argument(
+            "--list-items",
+            action="store_true",
+            dest="list_items",
+            help=(
+                "Parse with --list-items (or set CI_FDX_LIST_ITEMS=1); "
+                "diff reports include list_items when non-empty"
+            ),
+        )
+        ci_parser.add_argument(
+            "--display-boards",
+            action="store_true",
+            dest="display_boards",
+            help=(
+                "Parse with --display-boards (or CI_FDX_DISPLAY_BOARDS=1); "
+                "diff includes display_boards when non-empty"
+            ),
         )
         ci_parser.set_defaults(command="ci-fdx-diff")
 

--- a/schoonmaker/fdx/models.py
+++ b/schoonmaker/fdx/models.py
@@ -125,4 +125,10 @@ class Screenplay:
     document_ref: list[dict[str, Any]] = field(default_factory=list)
     alt_collection: list[dict[str, Any]] = field(default_factory=list)
     target_script_length: Optional[str] = None
+    # Beat/outline <ListItems> if ``FDXParser(include_list_items=True)``;
+    # not screenplay body; omitted from metadata totals.
+    list_items: list[dict[str, Any]] = field(default_factory=list)
+    # <DisplayBoards> (Story Map / Beat layout) if
+    # ``FDXParser(include_display_boards=True)``; omitted from metadata totals.
+    display_boards: list[dict[str, Any]] = field(default_factory=list)
     meta: dict[str, Any] = field(default_factory=dict)

--- a/schoonmaker/fdx/parser.py
+++ b/schoonmaker/fdx/parser.py
@@ -36,9 +36,26 @@ class FDXParser:
     - treat page/layout hints as metadata, not as structure
 
     Also parses Revisions, SmartType, Characters (top-level), ScriptNotes,
-    DocumentRef, AltCollection, TargetScriptLength. Other tags: see
-    notes/FDX_TODO.md.
+    DocumentRef, AltCollection, TargetScriptLength. Optional: ``ListItems``
+    and ``DisplayBoards`` when enabled — stored on the screenplay but not
+    merged into scenes or metadata totals. Other tags: see notes/FDX_TODO.md.
     """
+
+    def __init__(
+        self,
+        *,
+        include_list_items: bool = False,
+        include_display_boards: bool = False,
+    ) -> None:
+        self._include_list_items = include_list_items
+        self._include_display_boards = include_display_boards
+        # Per-<ListItem>; iterparse clears inner nodes before Paragraph end.
+        self._list_item_buf: dict[str, list[Any]] = {
+            "subordinates": [],
+            "paragraphs": [],
+        }
+        self._list_item_text_parts: list[str] = []
+        self._display_board_item_buf: list[dict[str, str]] = []
 
     def parse(self, path: str) -> Screenplay:
         root_meta = self._read_root_metadata(path)
@@ -66,6 +83,14 @@ class FDXParser:
             tag = self._local_name(elem.tag)
 
             if event == "start":
+                if self._include_list_items and tag == "ListItem":
+                    self._list_item_buf = {
+                        "subordinates": [],
+                        "paragraphs": [],
+                    }
+                    self._list_item_text_parts = []
+                if self._include_display_boards and tag == "DisplayBoard":
+                    self._display_board_item_buf = []
                 if tag == "Content":
                     parent = stack[-1] if stack else None
                     if parent == "FinalDraft":
@@ -140,6 +165,112 @@ class FDXParser:
                     screenplay.target_script_length = (
                         self._parse_target_script_length_elem(elem)
                     )
+                    elem.clear()
+                    stack.pop()
+                    continue
+
+                if (
+                    self._include_display_boards
+                    and tag == "DisplayBoard"
+                    and len(stack) >= 3
+                    and stack[-2] == "DisplayBoards"
+                    and stack[-3] == "FinalDraft"
+                ):
+                    board: dict[str, Any] = {
+                        "attrs": dict(elem.attrib),
+                        "items": list(self._display_board_item_buf),
+                    }
+                    screenplay.display_boards.append(board)
+                    self._display_board_item_buf = []
+                    elem.clear()
+                    stack.pop()
+                    continue
+
+                if (
+                    self._include_display_boards
+                    and tag == "Item"
+                    and len(stack) >= 3
+                    and stack[-1] == "Item"
+                    and stack[-2] == "DisplayBoard"
+                    and stack[-3] == "DisplayBoards"
+                ):
+                    self._display_board_item_buf.append(dict(elem.attrib))
+                    elem.clear()
+                    stack.pop()
+                    continue
+
+                if (
+                    self._include_list_items
+                    and tag == "ListItem"
+                    and len(stack) >= 3
+                    and stack[-2] == "ListItems"
+                    and stack[-3] == "FinalDraft"
+                ):
+                    item: dict[str, Any] = {"attrs": dict(elem.attrib)}
+                    if self._list_item_buf["subordinates"]:
+                        item["subordinate_to"] = [
+                            dict(x)
+                            for x in self._list_item_buf["subordinates"]
+                        ]
+                    if self._list_item_buf["paragraphs"]:
+                        item["content_paragraphs"] = self._list_item_buf[
+                            "paragraphs"
+                        ]
+                    screenplay.list_items.append(item)
+                    elem.clear()
+                    stack.pop()
+                    continue
+
+                if (
+                    self._include_list_items
+                    and tag == "SubordinateTo"
+                    and len(stack) >= 2
+                    and stack[-2] == "ListItem"
+                    and "ListItems" in stack
+                ):
+                    self._list_item_buf["subordinates"].append(
+                        dict(elem.attrib)
+                    )
+                    elem.clear()
+                    stack.pop()
+                    continue
+
+                if (
+                    self._include_list_items
+                    and tag == "Text"
+                    and len(stack) >= 5
+                    and stack[-1] == "Text"
+                    and stack[-2] == "Paragraph"
+                    and stack[-3] == "Content"
+                    and stack[-4] == "ListItem"
+                    and stack[-5] == "ListItems"
+                ):
+                    self._list_item_text_parts.append(elem.text or "")
+                    elem.clear()
+                    stack.pop()
+                    continue
+
+                if (
+                    self._include_list_items
+                    and tag == "Paragraph"
+                    and len(stack) >= 4
+                    and stack[-1] == "Paragraph"
+                    and stack[-2] == "Content"
+                    and stack[-3] == "ListItem"
+                    and stack[-4] == "ListItems"
+                ):
+                    raw = "".join(self._list_item_text_parts).strip()
+                    self._list_item_text_parts = []
+                    para = ParagraphInfo(
+                        type=elem.attrib.get("Type", "Unknown"),
+                        raw_text=raw,
+                        runs=[],
+                        attrs=dict(elem.attrib),
+                        scene_properties={},
+                        script_notes=[],
+                        alts=None,
+                    )
+                    self._list_item_buf["paragraphs"].append(asdict(para))
                     elem.clear()
                     stack.pop()
                     continue

--- a/schoonmaker/metadata.py
+++ b/schoonmaker/metadata.py
@@ -94,6 +94,9 @@ def compute_screenplay_metadata(screenplay: Screenplay) -> dict[str, Any]:
     dialogue_line, transition, etc.), characters per scene, lines per scene
     per character, and aggregate counts. Only generated when CLI --metadata
     is passed.
+
+    Totals reflect screenplay body only (``preamble`` + ``scenes``). Optional
+    ``list_items`` and ``display_boards`` are ignored here on purpose.
     """
     elements_by_type: dict[str, int] = {
         "action": 0,

--- a/schoonmaker/parse_json_diff.py
+++ b/schoonmaker/parse_json_diff.py
@@ -113,6 +113,38 @@ def _meta_counts(meta: dict[str, Any] | None) -> dict[str, int]:
     return out
 
 
+def _extras_list(data: dict[str, Any], key: str) -> list[Any]:
+    v = data.get(key)
+    return v if isinstance(v, list) else []
+
+
+def _canonical_json_digest(obj: Any) -> str:
+    blob = json.dumps(obj, sort_keys=True, ensure_ascii=False).encode("utf-8")
+    return hashlib.sha256(blob).hexdigest()
+
+
+def _append_board_extras_diff(
+    report: dict[str, Any],
+    a: dict[str, Any],
+    b: dict[str, Any],
+) -> None:
+    """Summarize optional ``list_items`` and ``display_boards`` sections."""
+    for key in ("list_items", "display_boards"):
+        la = _extras_list(a, key)
+        lb = _extras_list(b, key)
+        if not la and not lb:
+            continue
+        da = _canonical_json_digest(la)
+        db = _canonical_json_digest(lb)
+        report[key] = {
+            "count_before": len(la),
+            "count_after": len(lb),
+            "digest_before": da,
+            "digest_after": db,
+            "changed": da != db,
+        }
+
+
 def _location_list_to_map(rows: object) -> dict[str, int]:
     if not isinstance(rows, list):
         return {}
@@ -155,6 +187,10 @@ def build_diff_report(
     Prefer parse output with ``--metadata`` for full word, character, and
     location stats. ``--checksum`` avoids recomputing per-scene digests when
     lists match scene count.
+
+    If either parse JSON includes non-empty ``list_items`` or
+    ``display_boards`` (from ``parse --list-items`` / ``--display-boards``),
+    the report adds a short summary (counts, SHA-256 digests, ``changed``).
     """
     warnings: list[str] = []
     scenes_a = a.get("scenes")
@@ -374,6 +410,8 @@ def build_diff_report(
             "summary": {},
             "by_bucket": [],
         }
+
+    _append_board_extras_diff(report, a, b)
 
     return report
 

--- a/schoonmaker/version.py
+++ b/schoonmaker/version.py
@@ -1,1 +1,1 @@
-version = "1.2.0"
+version = "1.2.1"

--- a/schoonmaker/version.py
+++ b/schoonmaker/version.py
@@ -1,1 +1,1 @@
-version = "1.2.1"
+version = "1.3.0"

--- a/tests/test_ci_fdx_diff.py
+++ b/tests/test_ci_fdx_diff.py
@@ -82,8 +82,10 @@ def test_list_changed_fdx_paths_git_failure_raises(monkeypatch):
 def test_main_ci_fdx_diff_passes_repo(tmp_path, monkeypatch):
     captured: dict = {}
 
-    def fake_run(out, base, head, *, repo=None):
+    def fake_run(out, base, head, *, repo=None, **kwargs):
         captured["repo"] = repo
+        captured["list_items"] = kwargs.get("list_items", False)
+        captured["display_boards"] = kwargs.get("display_boards", False)
         return 0
 
     monkeypatch.setattr("schoonmaker.ci_fdx_diff.run_ci_fdx_diff", fake_run)
@@ -92,9 +94,45 @@ def test_main_ci_fdx_diff_passes_repo(tmp_path, monkeypatch):
         base_sha="a",
         head_sha="b",
         repo=str(tmp_path),
+        list_items=False,
+        display_boards=False,
     )
     assert main_ci_fdx_diff(args) == 0
     assert captured["repo"] == tmp_path.resolve()
+    assert captured["list_items"] is False
+    assert captured["display_boards"] is False
+
+
+def test_main_ci_fdx_diff_env_enables_board_extras(tmp_path, monkeypatch):
+    captured: dict = {}
+
+    def fake_run(
+        out,
+        base,
+        head,
+        *,
+        repo=None,
+        list_items=False,
+        display_boards=False,
+    ):
+        captured["list_items"] = list_items
+        captured["display_boards"] = display_boards
+        return 0
+
+    monkeypatch.setattr("schoonmaker.ci_fdx_diff.run_ci_fdx_diff", fake_run)
+    monkeypatch.setenv("CI_FDX_LIST_ITEMS", "1")
+    monkeypatch.setenv("CI_FDX_DISPLAY_BOARDS", "true")
+    args = SimpleNamespace(
+        output=str(tmp_path / "out"),
+        base_sha="a",
+        head_sha="b",
+        repo="",
+        list_items=False,
+        display_boards=False,
+    )
+    assert main_ci_fdx_diff(args) == 0
+    assert captured["list_items"] is True
+    assert captured["display_boards"] is True
 
 
 def test_run_ci_fdx_diff_skips_when_no_base(monkeypatch, tmp_path, capsys):

--- a/tests/test_ci_report_md.py
+++ b/tests/test_ci_report_md.py
@@ -1,0 +1,67 @@
+"""Tests for ``ci-report-md`` Markdown rendering."""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+
+from schoonmaker.ci_report_md import markdown_from_ci_reports
+from schoonmaker.ci_fdx_diff import path_fingerprint
+from schoonmaker.parse_json_diff import build_diff_report
+
+
+def test_markdown_from_ci_reports_empty_dir(tmp_path):
+    md = markdown_from_ci_reports(tmp_path)
+    assert "No `*-diff.json`" in md
+
+
+def test_markdown_uses_path_index_and_scenes(
+    sample_fdx_path,
+    tmp_path,
+):
+    ja = tmp_path / "a.json"
+    jb = tmp_path / "b.json"
+    from schoonmaker.cli import run_parse
+
+    for out in (ja, jb):
+        args = SimpleNamespace(
+            command="parse",
+            file=str(sample_fdx_path),
+            output=str(out),
+            metadata=True,
+            checksum=True,
+            file_info=False,
+            list_items=False,
+            display_boards=False,
+        )
+        run_parse(args)
+    da = json.loads(ja.read_text(encoding="utf-8"))
+    db = json.loads(jb.read_text(encoding="utf-8"))
+    rep = build_diff_report(da, db, label_a="before", label_b="after")
+    rel = "Scripts/my.fdx"
+    safe = path_fingerprint(rel)
+    diff_path = tmp_path / f"{safe}-diff.json"
+    diff_path.write_text(
+        json.dumps(rep, ensure_ascii=False),
+        encoding="utf-8",
+    )
+    (tmp_path / "path-index.tsv").write_text(
+        f"{safe}\t{rel}\n", encoding="utf-8"
+    )
+    md = markdown_from_ci_reports(tmp_path)
+    assert rel in md
+    assert "Scene count" in md
+
+
+def test_cli_ci_report_md_help():
+    repo_root = Path(__file__).resolve().parent.parent
+    r = subprocess.run(
+        [sys.executable, "-m", "schoonmaker", "ci-report-md", "-h"],
+        cwd=str(repo_root),
+        capture_output=True,
+        text=True,
+    )
+    assert r.returncode == 0, (r.stdout, r.stderr)

--- a/tests/test_cli_args.py
+++ b/tests/test_cli_args.py
@@ -31,6 +31,20 @@ class TestCLIArgs(unittest.TestCase):
         self.assertEqual(args.command, "parse")
         self.assertTrue(args.file_info)
 
+    def test_parse_list_items_flag(self):
+        args = CLIArgParser().parser.parse_args(
+            ["parse", "-f", "x.fdx", "--list-items"]
+        )
+        self.assertEqual(args.command, "parse")
+        self.assertTrue(args.list_items)
+
+    def test_parse_display_boards_flag(self):
+        args = CLIArgParser().parser.parse_args(
+            ["parse", "-f", "x.fdx", "--display-boards"]
+        )
+        self.assertEqual(args.command, "parse")
+        self.assertTrue(args.display_boards)
+
     def test_parse_metadata_checksum_file_info_flags_together(self):
         args = CLIArgParser().parser.parse_args(
             [
@@ -73,6 +87,20 @@ class TestCLIArgs(unittest.TestCase):
         self.assertEqual(args.output, "reports")
         self.assertEqual(args.base_sha, "aaa")
         self.assertEqual(args.head_sha, "bbb")
+
+    def test_ci_fdx_diff_list_items_and_display_boards_flags(self):
+        args = CLIArgParser().parser.parse_args(
+            [
+                "ci-fdx-diff",
+                "-o",
+                "r",
+                "--list-items",
+                "--display-boards",
+            ]
+        )
+        self.assertEqual(args.command, "ci-fdx-diff")
+        self.assertTrue(args.list_items)
+        self.assertTrue(args.display_boards)
 
 
 def test_python_m_schoonmaker_run_help():

--- a/tests/test_display_boards.py
+++ b/tests/test_display_boards.py
@@ -1,0 +1,70 @@
+"""Optional <DisplayBoards> parsing; excluded from script metadata totals."""
+
+from __future__ import annotations
+
+import json
+from types import SimpleNamespace
+
+from schoonmaker.cli import run_parse
+from schoonmaker.fdx import FDXParser
+from schoonmaker.metadata import compute_screenplay_metadata
+
+
+def test_display_boards_empty_by_default(sample_fdx12_path):
+    screenplay = FDXParser().parse(str(sample_fdx12_path))
+    assert screenplay.display_boards == []
+
+
+def test_parse_includes_display_boards_when_requested(sample_fdx12_path):
+    screenplay = FDXParser(include_display_boards=True).parse(
+        str(sample_fdx12_path)
+    )
+    assert len(screenplay.display_boards) == 2
+    types = {b["attrs"].get("Type") for b in screenplay.display_boards}
+    assert types == {"StoryMap", "Beat"}
+    story = next(
+        b
+        for b in screenplay.display_boards
+        if b["attrs"]["Type"] == "StoryMap"
+    )
+    beat = next(
+        b for b in screenplay.display_boards if b["attrs"]["Type"] == "Beat"
+    )
+    assert len(story["items"]) >= 14
+    assert len(beat["items"]) >= 15
+    assert all("Id" in it for it in story["items"])
+    placed = [it for it in beat["items"] if "Left" in it]
+    assert len(placed) >= 10
+
+
+def test_metadata_unchanged_by_display_boards(sample_fdx12_path):
+    base = FDXParser(include_display_boards=False).parse(
+        str(sample_fdx12_path)
+    )
+    with_db = FDXParser(include_display_boards=True).parse(
+        str(sample_fdx12_path)
+    )
+    assert len(with_db.display_boards) == 2
+    ma = compute_screenplay_metadata(base)
+    mb = compute_screenplay_metadata(with_db)
+    skip = {"characters", "scenes"}
+    for key in ma:
+        if key not in skip:
+            assert ma[key] == mb[key], key
+
+
+def test_parse_cli_display_boards_flag(sample_fdx12_path, tmp_path):
+    out = tmp_path / "out.json"
+    args = SimpleNamespace(
+        command="parse",
+        file=str(sample_fdx12_path),
+        output=str(out),
+        metadata=False,
+        checksum=False,
+        file_info=False,
+        list_items=False,
+        display_boards=True,
+    )
+    assert run_parse(args) == 0
+    data = json.loads(out.read_text(encoding="utf-8"))
+    assert len(data["display_boards"]) == 2

--- a/tests/test_list_items.py
+++ b/tests/test_list_items.py
@@ -1,0 +1,74 @@
+"""Optional <ListItems> parsing; beat board must not affect script metadata."""
+
+from __future__ import annotations
+
+import json
+from types import SimpleNamespace
+
+from schoonmaker.cli import run_parse
+from schoonmaker.fdx import FDXParser
+from schoonmaker.metadata import compute_screenplay_metadata
+
+
+def test_list_items_empty_by_default(sample_fdx12_path):
+    screenplay = FDXParser().parse(str(sample_fdx12_path))
+    assert screenplay.list_items == []
+
+
+def test_parse_includes_list_items_when_requested(sample_fdx12_path):
+    screenplay = FDXParser(include_list_items=True).parse(
+        str(sample_fdx12_path)
+    )
+    assert len(screenplay.list_items) >= 12
+    beats = [
+        x for x in screenplay.list_items if x["attrs"].get("Type") == "Beat"
+    ]
+    assert len(beats) >= 10
+    with_notes = [b for b in beats if b.get("content_paragraphs")]
+    assert len(with_notes) >= 1
+    para = with_notes[0]["content_paragraphs"][0]
+    assert para["raw_text"]
+
+
+def test_list_items_peer_link_attrs_only(sample_fdx12_path):
+    screenplay = FDXParser(include_list_items=True).parse(
+        str(sample_fdx12_path)
+    )
+    links = [
+        x
+        for x in screenplay.list_items
+        if x["attrs"].get("Type") == "PeerLink"
+    ]
+    assert len(links) >= 1
+    assert "content_paragraphs" not in links[0]
+
+
+def test_metadata_same_with_or_without_list_items(sample_fdx12_path):
+    base = FDXParser(include_list_items=False).parse(str(sample_fdx12_path))
+    with_li = FDXParser(include_list_items=True).parse(str(sample_fdx12_path))
+    assert len(with_li.list_items) > 0
+    ma = compute_screenplay_metadata(base)
+    mb = compute_screenplay_metadata(with_li)
+    # UUIDs differ per parse; ``characters`` / ``scenes`` embed scene ids.
+    skip = {"characters", "scenes"}
+    for key in ma:
+        if key not in skip:
+            assert ma[key] == mb[key], key
+
+
+def test_parse_cli_list_items_flag_json(sample_fdx12_path, tmp_path):
+    """``parse --list-items`` emits non-empty list_items in JSON."""
+    out = tmp_path / "out.json"
+    args = SimpleNamespace(
+        command="parse",
+        file=str(sample_fdx12_path),
+        output=str(out),
+        metadata=False,
+        checksum=False,
+        file_info=False,
+        list_items=True,
+        display_boards=False,
+    )
+    assert run_parse(args) == 0
+    data = json.loads(out.read_text(encoding="utf-8"))
+    assert len(data["list_items"]) >= 12

--- a/tests/test_parse_json_diff.py
+++ b/tests/test_parse_json_diff.py
@@ -28,6 +28,8 @@ def _run_parse_json(out_path, fdx_path, **flags):
             "metadata": flags.get("metadata", False),
             "checksum": flags.get("checksum", False),
             "file_info": flags.get("file_info", False),
+            "list_items": flags.get("list_items", False),
+            "display_boards": flags.get("display_boards", False),
         },
     )()
     run_parse(a)
@@ -149,6 +151,39 @@ def test_cli_diff_subprocess(sample_fdx_path, tmp_path):
     report = json.loads(out.read_text(encoding="utf-8"))
     assert report["diff_version"] == 1
     assert report["scenes"]["changed_indices"] == []
+
+
+def test_diff_report_includes_board_extras_when_present(
+    sample_fdx12_path,
+    tmp_path,
+):
+    ja = tmp_path / "a.json"
+    jb = tmp_path / "b.json"
+    _run_parse_json(
+        ja,
+        sample_fdx12_path,
+        metadata=True,
+        checksum=True,
+        list_items=True,
+        display_boards=True,
+    )
+    _run_parse_json(
+        jb,
+        sample_fdx12_path,
+        metadata=True,
+        checksum=True,
+        list_items=True,
+        display_boards=True,
+    )
+    ra = load_parse_json(ja)
+    rb = load_parse_json(jb)
+    report = build_diff_report(ra, rb)
+    assert "list_items" in report
+    assert report["list_items"]["count_before"] > 0
+    assert report["list_items"]["changed"] is False
+    assert "display_boards" in report
+    assert report["display_boards"]["count_before"] == 2
+    assert report["display_boards"]["changed"] is False
 
 
 def test_scene_digests_ignore_removed_checksums(sample_fdx_path, tmp_path):


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Medium risk because it extends the core FDX streaming parser and CI diff pipeline, which could affect parse performance/memory or introduce edge-case XML handling bugs, though the new sections are opt-in via flags/env vars.
> 
> **Overview**
> **Adds opt-in beat board/story map support to parse output.** `schoonmaker parse` (and `ci-fdx-diff`) gain `--list-items` and `--display-boards` to include Final Draft `<ListItems>` and `<DisplayBoards>` in the emitted JSON, stored on `Screenplay` but intentionally excluded from `--metadata` totals.
> 
> **Extends diff + CI reporting around those extras.** `schoonmaker diff` now adds a small summary for `list_items`/`display_boards` when present (counts + SHA-256 digests + `changed`), and `ci-fdx-diff` can enable the same parse options via CLI flags or `CI_FDX_LIST_ITEMS`/`CI_FDX_DISPLAY_BOARDS`.
> 
> **Adds GitHub Actions job-summary output.** New `schoonmaker ci-report-md` renders `ci-fdx-diff` `*-diff.json` files (with `path-index.tsv` labels) into Markdown suitable for appending to `GITHUB_STEP_SUMMARY`, and the example workflows/docs are updated accordingly; version bumps to `1.3.0` with new test coverage for all added behavior.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 07bdc76aac16c3c99f8fc406733823945db6c2d4. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->