### PR TITLE
Improving anything and everything

### DIFF
--- a/schoonmaker/ci_fdx_diff.py
+++ b/schoonmaker/ci_fdx_diff.py
@@ -7,12 +7,16 @@ Used by ``schoonmaker ci-fdx-diff``; orchestration lives here for unit tests.
 from __future__ import annotations
 
 import hashlib
+import json
 import os
 import shutil
 import subprocess
 import sys
+from datetime import datetime, timezone
 from pathlib import Path
 from types import SimpleNamespace
+from typing import Any
+from uuid import uuid4
 
 
 # git push event uses this when there is no parent (new branch, etc.)
@@ -27,6 +31,24 @@ def _env_truthy(name: str) -> bool:
 def path_fingerprint(repo_relative_path: str) -> str:
     """Stable hex id for a repo path (like diff report artifact names)."""
     return hashlib.sha256(repo_relative_path.encode("utf-8")).hexdigest()
+
+
+def _empty_baseline_parse_document() -> dict[str, Any]:
+    """
+    Minimal parse JSON compatible with ``build_diff_report`` (empty script).
+
+    Used when a .fdx did not exist at the base commit so the diff report can
+    treat the whole screenplay as added (same shape as ``schoonmaker parse``).
+    """
+    from schoonmaker.version import version as parser_version
+
+    return {
+        "nonce": uuid4().hex,
+        "parser_version": parser_version,
+        "parse_datetime": datetime.now(timezone.utc).isoformat(),
+        "scenes": [],
+        "metadata": {},
+    }
 
 
 def _git(
@@ -106,7 +128,8 @@ def run_ci_fdx_diff(
     display_boards: bool = False,
 ) -> int:
     """
-    For each changed .fdx between base and head: parse both, write diff JSON.
+    For each changed .fdx between base and head: parse head and baseline,
+    write ``*-diff.json`` (baseline is empty JSON when the file is new).
 
     Returns 0 on success, 1 on error, or 0 if skipped (no head or no base).
     """
@@ -223,26 +246,34 @@ def _run_ci_fdx_diff_loop(
             rc = run_parse(_parse_ns(before_fdx, before_json))
             if rc != 0:
                 return rc
-            rc = run_parse(_parse_ns(after_fdx, after_json))
-            if rc != 0:
-                return rc
-            rc = run_diff(
-                SimpleNamespace(
-                    command="diff",
-                    before=str(before_json),
-                    after=str(after_json),
-                    output=str(diff_out),
-                )
-            )
-            if rc != 0:
-                return rc
         else:
-            new_note = output_dir / f"{safe}-new.txt"
-            new_note.write_text(f"New file: {rel}\n", encoding="utf-8")
-            parse_only = output_dir / f"{safe}-parse.json"
-            rc = run_parse(_parse_ns(after_fdx, parse_only))
-            if rc != 0:
-                return rc
+            before_json.write_text(
+                json.dumps(
+                    _empty_baseline_parse_document(),
+                    indent=2,
+                    ensure_ascii=False,
+                )
+                + "\n",
+                encoding="utf-8",
+            )
+
+        rc = run_parse(_parse_ns(after_fdx, after_json))
+        if rc != 0:
+            return rc
+        rc = run_diff(
+            SimpleNamespace(
+                command="diff",
+                before=str(before_json),
+                after=str(after_json),
+                output=str(diff_out),
+            )
+        )
+        if rc != 0:
+            return rc
+
+        if not has_before:
+            parse_copy = output_dir / f"{safe}-parse.json"
+            shutil.copy2(after_json, parse_copy)
 
     return 0
 

--- a/schoonmaker/version.py
+++ b/schoonmaker/version.py
@@ -1,1 +1,1 @@
-version = "1.3.0"
+version = "1.3.1"

--- a/tests/test_ci_fdx_diff.py
+++ b/tests/test_ci_fdx_diff.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import hashlib
+import json
 import shutil
 import subprocess
 import sys
@@ -212,6 +213,77 @@ def test_run_ci_fdx_diff_git_integration(sample_fdx_path, tmp_path):
     safe = path_fingerprint("script.fdx")
     assert (out / f"{safe}-diff.json").is_file()
     assert "_tmp" not in [p.name for p in out.iterdir()]
+
+
+@pytest.mark.skipif(shutil.which("git") is None, reason="git not installed")
+def test_run_ci_fdx_diff_new_file_diff_json(sample_fdx_path, tmp_path):
+    """New .fdx: diff vs empty baseline; every scene is an add."""
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    (repo / "README").write_text("init\n", encoding="utf-8")
+    try:
+        subprocess.run(
+            ["git", "init"],
+            cwd=repo,
+            check=True,
+            capture_output=True,
+        )
+    except subprocess.CalledProcessError as e:
+        err = (e.stderr or b"") + (e.stdout or b"")
+        pytest.skip(f"git init unavailable: {err!r}")
+    subprocess.run(
+        ["git", "config", "user.email", "t@e.co"],
+        cwd=repo,
+        check=True,
+    )
+    subprocess.run(
+        ["git", "config", "user.name", "T"],
+        cwd=repo,
+        check=True,
+    )
+    subprocess.run(["git", "add", "README"], cwd=repo, check=True)
+    subprocess.run(
+        ["git", "commit", "-m", "first"],
+        cwd=repo,
+        check=True,
+        capture_output=True,
+    )
+    r = subprocess.run(
+        ["git", "rev-parse", "HEAD"],
+        cwd=repo,
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    base_sha = r.stdout.strip()
+
+    shutil.copy(sample_fdx_path, repo / "new.fdx")
+    subprocess.run(["git", "add", "new.fdx"], cwd=repo, check=True)
+    subprocess.run(
+        ["git", "commit", "-m", "add fdx"],
+        cwd=repo,
+        check=True,
+        capture_output=True,
+    )
+    r2 = subprocess.run(
+        ["git", "rev-parse", "HEAD"],
+        cwd=repo,
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    head_sha = r2.stdout.strip()
+
+    out = tmp_path / "reports_new"
+    rc = run_ci_fdx_diff(out, base_sha, head_sha, repo=repo)
+    assert rc == 0
+    safe = path_fingerprint("new.fdx")
+    assert (out / f"{safe}-diff.json").is_file()
+    assert (out / f"{safe}-parse.json").is_file()
+    data = json.loads((out / f"{safe}-diff.json").read_text(encoding="utf-8"))
+    assert data["scenes"]["count_before"] == 0
+    assert data["scenes"]["added_count"] == data["scenes"]["count_after"]
+    assert data["scenes"]["count_after"] > 0
 
 
 def test_cli_ci_fdx_diff_help():


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes the CI diff artifact format/behavior for new `.fdx` files by always emitting a `*-diff.json` (and copying `*-parse.json`), which could affect downstream consumers expecting the prior `*-new.txt`/parse-only outputs. Logic is localized to the CI helper and covered by new integration tests, reducing risk.
> 
> **Overview**
> `ci-fdx-diff` now always produces a `*-diff.json` for changed `.fdx` files, including *newly added* files by diffing against a generated empty-baseline parse document instead of writing a `*-new.txt` note and only a parse output.
> 
> For new files, it additionally writes a `*-parse.json` copy of the head parse result, and adds an integration test asserting that new-file diffs report all scenes as added. Version is bumped to `1.3.1`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2221c437cbc5c570077686587614eec4b32b0b3d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->